### PR TITLE
feat(receiver): optional flag was added to replace receiver==maker with ZERO_ADDRESS

### DIFF
--- a/src/limit-order/limit-order.spec.ts
+++ b/src/limit-order/limit-order.spec.ts
@@ -20,7 +20,38 @@ describe('Limit Order', () => {
             maker: new Address('0x00000000219ab540356cbb839cbe05303d7705fa')
         })
 
+        expect(order.receiver).toEqual(Address.ZERO_ADDRESS)
         expect(LimitOrder.fromCalldata(order.toCalldata())).toEqual(order)
+    })
+
+    it('should create limit order and set receiver == maker', () => {
+        const ext = new ExtensionBuilder().build()
+
+        const order = new LimitOrder(
+            {
+                makerAsset: new Address(
+                    '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+                ),
+                takerAsset: new Address(
+                    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+                ),
+                makingAmount: 1000000000000000000n,
+                takingAmount: 1420000000n,
+                maker: new Address(
+                    '0x00000000219ab540356cbb839cbe05303d7705fa'
+                ),
+                salt: LimitOrder.buildSalt(ext)
+            },
+            MakerTraits.default(),
+            ext,
+            {optimizeReceiverAddress: false}
+        )
+
+        expect(order.receiver).toEqual(order.maker)
+        expect(LimitOrder.fromCalldata(order.toCalldata())).toEqual(order)
+        expect(LimitOrder.fromDataAndExtension(order.build(), ext)).toEqual(
+            order
+        )
     })
 
     it('should create limit order with passed salt', () => {


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
Before, the `receiver` field gas optimization was enforced (when receiver==maker, set `ZERO_ADDRESS` as receiver). But there're use cases when this shouldn't be enforced. So, added an optional flag `optimizeReceiverAddress` to the constructor to manage the expectations

## Testing & Verification
**How was this tested?**
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback
