### PR TITLE
docs(PT9-760): add fill-or-kill order creation and cancel examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install '@1inch/limit-order-sdk'
 ### Order creation
 ```typescript
 import {LimitOrder, MakerTraits, Address, Sdk, randBigInt, FetchProviderConnector} from "@1inch/limit-order-sdk"
+import {UINT_40_MAX} from "@1inch/byte-utils"
 import {Wallet} from 'ethers'
 
 // it is a well-known test private key, do not use it in production
@@ -24,8 +25,6 @@ const authKey = '...'
 const maker = new Wallet(privKey)
 const expiresIn = 120n // 2m
 const expiration = BigInt(Math.floor(Date.now() / 1000)) + expiresIn
-
-const UINT_40_MAX = (1n << 40n) - 1n
 
 // see MakerTraits.ts
 const makerTraits = MakerTraits.default()
@@ -73,8 +72,8 @@ By default a limit order can be filled in several parts. To create an order that
 
 ```typescript
 import {MakerTraits, randBigInt} from "@1inch/limit-order-sdk"
+import {UINT_40_MAX} from "@1inch/byte-utils"
 
-const UINT_40_MAX = (1n << 40n) - 1n
 const expiration = BigInt(Math.floor(Date.now() / 1000)) + 3600n // 1h
 
 const makerTraits = MakerTraits.default()
@@ -89,7 +88,7 @@ const makerTraits = MakerTraits.default()
 Rules:
 
 - Give every such order its own random nonce via `withNonce` - never reuse a nonce across active orders.
-- Do not combine this mode with `withEpoch` / `enableEpochManagerCheck` - such orders are rejected on submit.
+- Do not call `withEpoch` on these orders - submit rejects fill-or-kill orders that use epoch.
 - If the order cannot be filled in full right away, it stays open until it fills, expires or is cancelled. It will never be filled partially.
 
 The orderbook API returns `partialFillsAllowed: false` for these orders.
@@ -99,22 +98,30 @@ The orderbook API returns `partialFillsAllowed: false` for these orders.
 Cancellation is on-chain, using the maker traits and the hash of the order (keep both after submitting):
 
 ```typescript
+import {getLimitOrderContract} from "@1inch/limit-order-sdk"
 import {Contract, JsonRpcProvider, Wallet} from "ethers"
 
-const LOP_V4 = '0x111111125421ca6dc452d289314280a0f8842a65'
+const chainId = 1 // same chainId as create/submit
 const abi = [
     'function cancelOrder(uint256 makerTraits, bytes32 orderHash)',
     'function cancelOrders(uint256[] makerTraits, bytes32[] orderHashes)'
 ]
 
 const signer = new Wallet(privKey, new JsonRpcProvider(rpcUrl))
-const lop = new Contract(LOP_V4, abi, signer)
+const lop = new Contract(getLimitOrderContract(chainId), abi, signer)
+
+// keep after submit
+const traits = order.build().makerTraits // string
+const orderHash = order.getOrderHash(chainId)
 
 // single order
-await (await lop.cancelOrder(order.build().makerTraits, orderHash)).wait()
+await (await lop.cancelOrder(BigInt(traits), orderHash)).wait()
 
 // several orders in one transaction (traits[i] must belong to hashes[i])
-await (await lop.cancelOrders(traitsArray, hashesArray)).wait()
+await (await lop.cancelOrders(
+    openOrders.map((o) => BigInt(o.build().makerTraits)),
+    openOrders.map((o) => o.getOrderHash(chainId))
+)).wait()
 ```
 
 Note: cancelling all orders by epoch (`increaseEpoch`) does not affect orders with partial fills disabled - cancel them by hash as shown above.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const maker = new Wallet(privKey)
 const expiresIn = 120n // 2m
 const expiration = BigInt(Math.floor(Date.now() / 1000)) + expiresIn
 
-const UINT_40_MAX = (1n << 48n) - 1n
+const UINT_40_MAX = (1n << 40n) - 1n
 
 // see MakerTraits.ts
 const makerTraits = MakerTraits.default()
@@ -66,6 +66,58 @@ When the limit-orders API returns integrator fee fields from `/fee-info`, `Sdk.c
 **Source / track code:** the API returns bare hex (e.g. `aba10994`), not `0x`-prefixed. `setSource` keccak-hashes non-`0x` values into the salt track bits — do not “fix” the API value by adding `0x`, or attribution will break. If you pass an explicit `orderInfo.salt`, the API `source` is not applied; your salt’s track bits win.
 
 **`Bps.fromPercent` / `fromSharePercent`:** values with more than 2 decimal places are truncated to 1 bps precision (e.g. `0.125` → 12 bps) instead of throwing. Negative values are rejected.
+
+### Orders with partial fills disabled (fill-or-kill)
+
+By default a limit order can be filled in several parts. To create an order that must be filled entirely in a single transaction - or not at all - disable partial fills:
+
+```typescript
+import {MakerTraits, randBigInt} from "@1inch/limit-order-sdk"
+
+const UINT_40_MAX = (1n << 40n) - 1n
+const expiration = BigInt(Math.floor(Date.now() / 1000)) + 3600n // 1h
+
+const makerTraits = MakerTraits.default()
+    .withExpiration(expiration)
+    .withNonce(randBigInt(UINT_40_MAX)) // required: unique nonce per order
+    .disablePartialFills()
+    .disableMultipleFills()
+
+// then create, sign and submit the order as usual - see "Order creation" above
+```
+
+Rules:
+
+- Give every such order its own random nonce via `withNonce` - never reuse a nonce across active orders.
+- Do not combine this mode with `withEpoch` / `enableEpochManagerCheck` - such orders are rejected on submit.
+- If the order cannot be filled in full right away, it stays open until it fills, expires or is cancelled. It will never be filled partially.
+
+The orderbook API returns `partialFillsAllowed: false` for these orders.
+
+#### Cancelling orders
+
+Cancellation is on-chain, using the maker traits and the hash of the order (keep both after submitting):
+
+```typescript
+import {Contract, JsonRpcProvider, Wallet} from "ethers"
+
+const LOP_V4 = '0x111111125421ca6dc452d289314280a0f8842a65'
+const abi = [
+    'function cancelOrder(uint256 makerTraits, bytes32 orderHash)',
+    'function cancelOrders(uint256[] makerTraits, bytes32[] orderHashes)'
+]
+
+const signer = new Wallet(privKey, new JsonRpcProvider(rpcUrl))
+const lop = new Contract(LOP_V4, abi, signer)
+
+// single order
+await (await lop.cancelOrder(order.build().makerTraits, orderHash)).wait()
+
+// several orders in one transaction (traits[i] must belong to hashes[i])
+await (await lop.cancelOrders(traitsArray, hashesArray)).wait()
+```
+
+Note: cancelling all orders by epoch (`increaseEpoch`) does not affect orders with partial fills disabled - cancel them by hash as shown above.
 
 
 ### RFQ Order creation


### PR DESCRIPTION
## Summary
- Adds a partner-facing README section for orders with partial fills disabled (fill-or-kill): create via MakerTraits, unique nonce, cancel one / cancel many
- Fixes the existing order-creation example `UINT_40_MAX` mask (`1n << 48n` → `1n << 40n`) so copy-paste matches `withNonce` constraints

## Test plan
- [ ] Review README wording for partner clarity (no internal protocol details)
- [ ] Confirm create / cancel snippets match PT9-760 partner guide intent
- [ ] Docs-only: no SDK release required for GitHub README; npm page updates on next publish